### PR TITLE
Upgraded rollbar to newest version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,5 @@ build/Release
 # Dependency directory
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git
 node_modules
+
+.envrc

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ A Hapi plugin for rollbar painless integration
             options: {
                 accessToken: '',
                 environment: '', // optional, defaults to process.env.NODE_ENV
-                exitOnUncaughtException: true // optional, defaults to true
+                handleUncaughtExceptions: true // optional, defaults to false
             }
         }, function (err) {
             if (err) throw err;
@@ -29,7 +29,6 @@ A Hapi plugin for rollbar painless integration
 
     server.plugins['rollbar-hapi'].rollbar // the rollbar module, already initialised
 
-    server.methods.handleError(err, req, next); // == rollbar.handleError
-    server.methods.handleErrorWithPayloadData(err, opts, req, next); // == rollbar.handleErrorWithPayloadData
-    server.methods.reportMessage(msg, level, req, next); // == rollbar.reportMessage
-    server.methods.reportMessageWithPayloadData(msg, opts, req, next); // == rollbar.reportMessageWithPayloadData
+    The exposed `rollbar` above can be used to access rollbar's `log`, `debug`, `info`, `warning`, 
+    `error`, and `critical` methods
+

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,104 +34,75 @@
  * *******************************************************************/
 
 // Load modules
-var rollbar = require('rollbar');
+var Rollbar = require('rollbar');
 var util = require('util');
 
 exports.register = function (server, options, next) {
-    var preError = options.preError || function preError(err) { return err; };
-    var rollbarKey = options.accessToken;
-    var rollbarOpts = options;
-    rollbarOpts.environment = rollbarOpts.environment || process.env.NODE_ENV;
-    rollbarOpts.exitOnUncaughtException = typeof options.exitOnUncaughtException !== 'undefined' ?
-        options.exitOnUncaughtException : true;
+	var preError = options.preError || function preError(err) { return err; };
 
-    rollbar.init(rollbarKey, rollbarOpts);
-    rollbar.handleUncaughtExceptions(rollbarKey, rollbarOpts);
+	var rollbarOpts = options;
+	rollbarOpts.environment = rollbarOpts.environment || process.env.NODE_ENV;
+	rollbarOpts.handleUncaughtExceptions = typeof options.handleUncaughtExceptions !== 'undefined' ?
+		options.handleUncaughtExceptions : false;
+	var rollbarAccessToken = rollbarOpts.accessToken;
+	rollbarOpts.enabled = !!rollbarAccessToken;
 
-    server.on('stop', function stop() {
-        rollbar.shutdown();
-    });
+	var rollbar = new Rollbar({
+		accessToken: rollbarOpts.accessToken,
+		environment: rollbarOpts.environment,
+		handleUncaughtExceptions: rollbarOpts.handleUncaughtExceptions,
+		enabled: rollbarOpts.enabled
+	});
+    
 
-    server.ext('onPreResponse', function onPreResponse(request, next) {
-        var response = preError(request.response);
-        if (response && response.isBoom) {
-            rollbar.handleErrorWithPayloadData(response, response.output, request, logError);
-        }
+	server.ext('onPreResponse', function onPreResponse(request, next) {
+		var response = preError(request.response);
+		if (response && response.isBoom) {
+			rollbar.error(response, request, response.output, logError);
+		}
+		next.continue();
+	});
 
-        next.continue();
-    });
+	server.on('request-internal', function requestInternal(request, event, tags) {
+		if (tags.error && tags.state) {
+			return rollbar.warning(JSON.stringify(event), formatReq(request), logError);
+		}
+	});
 
-    server.on('log', function rollbarLog(event, tags) {
-        if (tags.rollbarError) {
-            return rollbar.handleError(event.err, formatReq(event.req));
-        }
-        if (tags.rollbarMessage) {
-            return rollbar.reportMessage(event.msg, event.level || 'info', formatReq(event.req), logError);
-        }
-    });
+	server.on('request-error', function requestError(request, err) {
+		return rollbar.error(err, formatReq(request), logError);
+	});
 
-    server.on('request-internal', function requestInternal(request, event, tags) {
-        if (tags.error && tags.state) {
-            return rollbar.reportMessage(event, event.level || 'warning', formatReq(request), logError);
-        }
-    });
+	server.expose('rollbar', rollbar);
 
-    server.on('request-error', function requestError(request, err) {
-        return rollbar.handleError(err, formatReq(request), logError);
-    });
-
-    server.expose('rollbar', rollbar);
-
-    server.method('handleError', function handleError(err, req, next) {
-        rollbar.handleError(err, formatReq(req), logError);
-        next();
-    });
-
-    server.method('handleErrorWithPayloadData', function handleErrorWithPayloadData(err, opts, req, next) {
-        rollbar.handleErrorWithPayloadData(err, opts, formatReq(req), logError);
-        next();
-    });
-
-    server.method('reportMessage', function reportMessage(msg, level, req, next) {
-        rollbar.reportMessage(msg, level, formatReq(req), logError);
-        next();
-    });
-
-    server.method('reportMessageWithPayloadData', function reportMessageWithPayloadData(msg, opts, req, next) {
-        rollbar.reportMessageWithPayloadData(msg, opts, formatReq(req), logError);
-        next();
-    });
-
-    next();
 };
 
 exports.register.attributes = {
-    pkg: require('../package.json')
-};
+	pkg: require('../package.json') };
 
 function logError(err, rbPayload, rbResp) {
-    if (err) {
-        util.log(err);
-        return;
-    }
-    if (rbResp && rbResp.uuid) {
-        util.log('[Rollbar] link: https://rollbar.com/occurrence/uuid/?uuid=' + rbResp.uuid);
-    }
+	if (err) {
+		util.log(err);
+		return;
+	}
+	if (rbResp && rbResp.uuid) {
+		util.log('[Rollbar] link: https://rollbar.com/occurrence/uuid/?uuid=' + rbResp.uuid);
+	}
 }
 
 function formatReq(request) {
-    if (!request) return;
+	if (!request) return;
 
-    let rollbarRequest = {
-        ip: request.info.remoteAddress,
-        headers: request.headers,
-        url: request.url.path,
-        method: request.method,
-        protocol: request.connection.info.protocol,
-        route: {
-            path: request.route.path
-        }
-    };
+	let rollbarRequest = {
+		ip: request.info.remoteAddress,
+		headers: request.headers,
+		url: request.url.path,
+		method: request.method,
+		protocol: request.connection.info.protocol,
+		route: {
+			path: request.route.path
+		}
+	};
 
-    return rollbarRequest;
+	return rollbarRequest;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1539 @@
+{
+    "name": "rollbar-hapi",
+    "version": "0.0.7",
+    "lockfileVersion": 1,
+    "dependencies": {
+        "accept": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/accept/-/accept-2.1.4.tgz",
+            "integrity": "sha1-iHr1TO7lx/RDBGGXHsQAxh0JrLs=",
+            "dev": true
+        },
+        "acorn": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.0.3.tgz",
+            "integrity": "sha1-xGDfCEkUY/AozLguqzcwvwEIez0=",
+            "dev": true
+        },
+        "acorn-jsx": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
+            "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
+            "dev": true,
+            "dependencies": {
+                "acorn": {
+                    "version": "3.3.0",
+                    "resolved": "https://registry.npmjs.org/acorn/-/acorn-3.3.0.tgz",
+                    "integrity": "sha1-ReN/s56No/JbruP/U2niu18iAXo=",
+                    "dev": true
+                }
+            }
+        },
+        "ajv": {
+            "version": "4.11.8",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+            "integrity": "sha1-gv+wKynmYq5TvcIK8VlHcGc5xTY=",
+            "dev": true
+        },
+        "ajv-keywords": {
+            "version": "1.5.1",
+            "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-1.5.1.tgz",
+            "integrity": "sha1-MU3QpLM2j609/NxU7eYXG4htrzw=",
+            "dev": true
+        },
+        "align-text": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+            "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+            "dev": true
+        },
+        "amdefine": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+            "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU=",
+            "dev": true
+        },
+        "ammo": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/ammo/-/ammo-2.0.4.tgz",
+            "integrity": "sha1-v4CqshFpjqePY+9efxE91dnokX8=",
+            "dev": true
+        },
+        "ansi-escapes": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+            "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+            "dev": true
+        },
+        "ansi-regex": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+            "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+            "dev": true
+        },
+        "ansi-styles": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+            "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+            "dev": true
+        },
+        "argparse": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.9.tgz",
+            "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
+            "dev": true
+        },
+        "array-union": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+            "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
+            "dev": true
+        },
+        "array-uniq": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/array-uniq/-/array-uniq-1.0.3.tgz",
+            "integrity": "sha1-r2rId6Jcx/dOBYiUdThY39sk/bY=",
+            "dev": true
+        },
+        "arrify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/arrify/-/arrify-1.0.1.tgz",
+            "integrity": "sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=",
+            "dev": true
+        },
+        "assertion-error": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.0.2.tgz",
+            "integrity": "sha1-E8pRXYYgbaC6xm6DTdOX2HWBCUw=",
+            "dev": true
+        },
+        "async": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/async/-/async-1.2.1.tgz",
+            "integrity": "sha1-pIFqF81f9RbfosdpikUzabl5DeA=",
+            "dev": true
+        },
+        "b64": {
+            "version": "3.0.2",
+            "resolved": "https://registry.npmjs.org/b64/-/b64-3.0.2.tgz",
+            "integrity": "sha1-ep1gRmrfe43hFMvfZRpf38yQiU0=",
+            "dev": true
+        },
+        "babel-code-frame": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.22.0.tgz",
+            "integrity": "sha1-AnYgvuVnqIwyVhV05/0IAdMxGOQ=",
+            "dev": true
+        },
+        "balanced-match": {
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+            "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
+            "dev": true
+        },
+        "boom": {
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/boom/-/boom-5.1.0.tgz",
+            "integrity": "sha1-Awj6jpJM1tQtnDv0iDvcmPDnHfg=",
+            "dev": true
+        },
+        "bossy": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/bossy/-/bossy-3.0.4.tgz",
+            "integrity": "sha1-+a6fJugbQaMY9O4Ng2huSlwlB7k=",
+            "dev": true
+        },
+        "brace-expansion": {
+            "version": "1.1.7",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.7.tgz",
+            "integrity": "sha1-Pv/DxQ4ABTH7cg6v+A8K6O8jz1k=",
+            "dev": true
+        },
+        "call": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/call/-/call-4.0.2.tgz",
+            "integrity": "sha1-33b19R7o3Ui4VqyEAPfmnm1zmcQ=",
+            "dev": true
+        },
+        "caller-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
+            "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
+            "dev": true
+        },
+        "callsites": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/callsites/-/callsites-0.2.0.tgz",
+            "integrity": "sha1-r6uWJikQp/M8GaV3WCXGnzTjUMo=",
+            "dev": true
+        },
+        "camelcase": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+            "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
+            "dev": true,
+            "optional": true
+        },
+        "catbox": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/catbox/-/catbox-7.1.4.tgz",
+            "integrity": "sha1-ipUO0YtkuoCIwa4TLoXFhHnStsw=",
+            "dev": true
+        },
+        "catbox-memory": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/catbox-memory/-/catbox-memory-2.0.4.tgz",
+            "integrity": "sha1-Qz4lWQLK9UIz0ShkKcj03xToItU=",
+            "dev": true
+        },
+        "center-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+            "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+            "dev": true,
+            "optional": true
+        },
+        "chai": {
+            "version": "4.0.2",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-4.0.2.tgz",
+            "integrity": "sha1-L3MnxN5vOF3XeHmZ4qsCaXoyuDs=",
+            "dev": true
+        },
+        "chalk": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+            "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+            "dev": true,
+            "dependencies": {
+                "supports-color": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                    "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+                    "dev": true
+                }
+            }
+        },
+        "check-error": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+            "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII=",
+            "dev": true
+        },
+        "circular-json": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.3.1.tgz",
+            "integrity": "sha1-vos2rvzN6LPKeqLWr8B6NyQsDS0=",
+            "dev": true
+        },
+        "cli-cursor": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+            "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+            "dev": true
+        },
+        "cli-width": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.1.0.tgz",
+            "integrity": "sha1-sjTKIJsp72b8UY2bmNWEewDt8Ao=",
+            "dev": true
+        },
+        "cliui": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+            "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
+            "dev": true,
+            "optional": true,
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.2",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+                    "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
+                    "dev": true,
+                    "optional": true
+                }
+            }
+        },
+        "co": {
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
+        },
+        "code-point-at": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+            "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+            "dev": true
+        },
+        "combined-stream": {
+            "version": "0.0.7",
+            "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-0.0.7.tgz",
+            "integrity": "sha1-ATfmV7qlp1QcV6w3rF/AfXO03B8=",
+            "dev": true
+        },
+        "component-emitter": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.1.2.tgz",
+            "integrity": "sha1-KWWU8nU9qmOZbSrwjRWpURbJrsM=",
+            "dev": true
+        },
+        "concat-map": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+            "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+            "dev": true
+        },
+        "concat-stream": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
+            "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
+            "dev": true,
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                },
+                "readable-stream": {
+                    "version": "2.2.11",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.11.tgz",
+                    "integrity": "sha512-h+8+r3MKEhkiVrwdKL8aWs1oc1VvBu33ueshOvS26RsZQ3Amhx/oO3TKe4lApSV9ueY6as8EAh7mtuFjdlhg9Q==",
+                    "dev": true
+                },
+                "string_decoder": {
+                    "version": "1.0.2",
+                    "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.2.tgz",
+                    "integrity": "sha1-sp4fThEl+pehA4K4pTNze3SR4Xk=",
+                    "dev": true
+                }
+            }
+        },
+        "console-polyfill": {
+            "version": "github:rollbar/console-polyfill#eab6ff9d2b7597fc2f259baa18100556bdb94dbe",
+            "dev": true
+        },
+        "content": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/content/-/content-3.0.4.tgz",
+            "integrity": "sha1-yj3eBEgPElGbcVJuxEvUiN37P+8=",
+            "dev": true
+        },
+        "cookiejar": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.0.1.tgz",
+            "integrity": "sha1-PRJ1L2rfaKiS8zJDNJK9WBK7Zo8=",
+            "dev": true
+        },
+        "core-util-is": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+            "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+            "dev": true
+        },
+        "cryptiles": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+            "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+            "dev": true
+        },
+        "d": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
+            "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+            "dev": true
+        },
+        "debug": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
+            "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+            "dev": true
+        },
+        "decache": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/decache/-/decache-3.1.0.tgz",
+            "integrity": "sha1-T1A2+9ZYH8yXI3rDlUokS5U2wto=",
+            "dev": true,
+            "optional": true
+        },
+        "decamelize": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+            "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+            "dev": true,
+            "optional": true
+        },
+        "deep-eql": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-2.0.2.tgz",
+            "integrity": "sha1-sbrAblbwp2d3aG1Qyf63XC7XZ5o=",
+            "dev": true,
+            "dependencies": {
+                "type-detect": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-3.0.0.tgz",
+                    "integrity": "sha1-RtDMhVOrt7E6NSsNbeov1Y8tm1U=",
+                    "dev": true
+                }
+            }
+        },
+        "deep-is": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+            "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+            "dev": true
+        },
+        "del": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
+            "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
+            "dev": true
+        },
+        "delayed-stream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-0.0.5.tgz",
+            "integrity": "sha1-1LH0OpPoKW3+AmlPRoC8N6MTxz8=",
+            "dev": true
+        },
+        "diff": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/diff/-/diff-3.2.0.tgz",
+            "integrity": "sha1-yc45Okt8vQsFinJck98pkCeGj/k=",
+            "dev": true
+        },
+        "doctrine": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.0.0.tgz",
+            "integrity": "sha1-xz2NKQnSIpHhoAejlYBNqLZl/mM=",
+            "dev": true,
+            "dependencies": {
+                "isarray": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                    "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+                    "dev": true
+                }
+            }
+        },
+        "error-stack-parser": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-1.3.3.tgz",
+            "integrity": "sha1-+tpuOpzSsOCA5tb8dRQYZJc081w=",
+            "dev": true
+        },
+        "es5-ext": {
+            "version": "0.10.23",
+            "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.23.tgz",
+            "integrity": "sha1-dXi1G+l0IHpUh4IbVlOMIk5Oezg=",
+            "dev": true
+        },
+        "es6-iterator": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.1.tgz",
+            "integrity": "sha1-jjGcnwRTv1ddN0lAplWSDlnKVRI=",
+            "dev": true
+        },
+        "es6-map": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
+            "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
+            "dev": true
+        },
+        "es6-set": {
+            "version": "0.1.5",
+            "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
+            "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
+            "dev": true
+        },
+        "es6-symbol": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
+            "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
+            "dev": true
+        },
+        "es6-weak-map": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
+            "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
+            "dev": true
+        },
+        "escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+            "dev": true
+        },
+        "escope": {
+            "version": "3.6.0",
+            "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
+            "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
+            "dev": true
+        },
+        "eslint": {
+            "version": "3.19.0",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-3.19.0.tgz",
+            "integrity": "sha1-yPxiAcf0DdCJQbh8CFdnOGpnmsw=",
+            "dev": true
+        },
+        "eslint-config-hapi": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-config-hapi/-/eslint-config-hapi-10.0.0.tgz",
+            "integrity": "sha1-mYCv/XYQPrwf7JK0Vjg0XbGTSPU=",
+            "dev": true
+        },
+        "eslint-plugin-hapi": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/eslint-plugin-hapi/-/eslint-plugin-hapi-4.0.0.tgz",
+            "integrity": "sha1-RKouRfeTmlI5Kc2DK7mqEpqV6CM=",
+            "dev": true
+        },
+        "espree": {
+            "version": "3.4.3",
+            "resolved": "https://registry.npmjs.org/espree/-/espree-3.4.3.tgz",
+            "integrity": "sha1-KRC1zNSc6JPC//+qtP2LOjG4I3Q=",
+            "dev": true
+        },
+        "esprima": {
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+            "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM=",
+            "dev": true
+        },
+        "esquery": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
+            "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
+            "dev": true
+        },
+        "esrecurse": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.1.0.tgz",
+            "integrity": "sha1-RxO2U2rffyrE8yfVWed1a/9kgiA=",
+            "dev": true,
+            "dependencies": {
+                "estraverse": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.1.1.tgz",
+                    "integrity": "sha1-9srKcokzqFDvkGYdDheYK6RxEaI=",
+                    "dev": true
+                }
+            }
+        },
+        "estraverse": {
+            "version": "4.2.0",
+            "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+            "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+            "dev": true
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+            "dev": true
+        },
+        "event-emitter": {
+            "version": "0.3.5",
+            "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+            "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
+            "dev": true
+        },
+        "exit-hook": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+            "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
+            "dev": true
+        },
+        "extend": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/extend/-/extend-1.2.1.tgz",
+            "integrity": "sha1-oPX9bPyDpf5J72mNYOyKYk3UV2w=",
+            "dev": true
+        },
+        "fast-levenshtein": {
+            "version": "2.0.6",
+            "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+            "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+            "dev": true
+        },
+        "figures": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+            "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+            "dev": true
+        },
+        "file-entry-cache": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
+            "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
+            "dev": true
+        },
+        "find": {
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/find/-/find-0.2.7.tgz",
+            "integrity": "sha1-evvQD48IxbYi+Xzab3FBc9VHuz8=",
+            "dev": true,
+            "optional": true
+        },
+        "find-rc": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/find-rc/-/find-rc-3.0.1.tgz",
+            "integrity": "sha1-VKQXg3DxC8k3H6jRssKAmir6DM4=",
+            "dev": true
+        },
+        "flat-cache": {
+            "version": "1.2.2",
+            "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.2.2.tgz",
+            "integrity": "sha1-+oZxTnLCHbiGAXYezy9VXRq8a5Y=",
+            "dev": true
+        },
+        "form-data": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.1.3.tgz",
+            "integrity": "sha1-TuQ0bm61Ni6DRKAgdb2NvYxzc+o=",
+            "dev": true,
+            "dependencies": {
+                "async": {
+                    "version": "0.9.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+                    "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0=",
+                    "dev": true
+                }
+            }
+        },
+        "formatio": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/formatio/-/formatio-1.2.0.tgz",
+            "integrity": "sha1-87IWfZBoxGmKjVH092CjmlTYGOs=",
+            "dev": true
+        },
+        "formidable": {
+            "version": "1.0.14",
+            "resolved": "https://registry.npmjs.org/formidable/-/formidable-1.0.14.tgz",
+            "integrity": "sha1-Kz9MQRy7X91pXESEPiojUUpDIxo=",
+            "dev": true
+        },
+        "fs.realpath": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+            "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+            "dev": true
+        },
+        "generate-function": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+            "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ=",
+            "dev": true
+        },
+        "generate-object-property": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+            "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+            "dev": true
+        },
+        "get-func-name": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
+            "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+            "dev": true
+        },
+        "glob": {
+            "version": "7.1.1",
+            "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.1.tgz",
+            "integrity": "sha1-gFIR3wT6rxxjo2ADBs31reULLsg=",
+            "dev": true
+        },
+        "globals": {
+            "version": "9.18.0",
+            "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
+            "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+            "dev": true
+        },
+        "globby": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
+            "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
+            "dev": true
+        },
+        "graceful-fs": {
+            "version": "4.1.11",
+            "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+            "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+            "dev": true
+        },
+        "handlebars": {
+            "version": "4.0.10",
+            "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.10.tgz",
+            "integrity": "sha1-PTDHGLCaPZbyPqTMH0A8TTup/08=",
+            "dev": true,
+            "dependencies": {
+                "async": {
+                    "version": "1.5.2",
+                    "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+                    "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+                    "dev": true
+                },
+                "source-map": {
+                    "version": "0.4.4",
+                    "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+                    "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+                    "dev": true
+                }
+            }
+        },
+        "hapi": {
+            "version": "16.4.2",
+            "resolved": "https://registry.npmjs.org/hapi/-/hapi-16.4.2.tgz",
+            "integrity": "sha512-Lx2TnP8LdNyHHWEbN+/EWM6ykTjLu8HwkGjcl5xVHQuum7qbIIGhuyVQfSIPidgmAhRfyCv8KgWCvDYxLjMTSA==",
+            "dev": true
+        },
+        "hapi-capitalize-modules": {
+            "version": "1.1.6",
+            "resolved": "https://registry.npmjs.org/hapi-capitalize-modules/-/hapi-capitalize-modules-1.1.6.tgz",
+            "integrity": "sha1-eZEXFBXhXmqjIx5k3ac8gUZmUxg=",
+            "dev": true
+        },
+        "hapi-for-you": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/hapi-for-you/-/hapi-for-you-1.0.0.tgz",
+            "integrity": "sha1-02L77o172pwseAHiB+WlzRoLans=",
+            "dev": true
+        },
+        "hapi-scope-start": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/hapi-scope-start/-/hapi-scope-start-2.1.1.tgz",
+            "integrity": "sha1-dJWnJv5yt7yo3izcwdh82M5qtPI=",
+            "dev": true
+        },
+        "has-ansi": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+            "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+            "dev": true
+        },
+        "heavy": {
+            "version": "4.0.4",
+            "resolved": "https://registry.npmjs.org/heavy/-/heavy-4.0.4.tgz",
+            "integrity": "sha1-NskTNsAMz+hSyqTRUwhjNc0vAOk=",
+            "dev": true
+        },
+        "hoek": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.1.1.tgz",
+            "integrity": "sha1-nMVz/7ore0CPtenCoTeWvpTN3Ok=",
+            "dev": true
+        },
+        "ignore": {
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.3.tgz",
+            "integrity": "sha1-QyNS5XrM2HqzEQ6C0/6g5HgSFW0=",
+            "dev": true
+        },
+        "imurmurhash": {
+            "version": "0.1.4",
+            "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
+        },
+        "inflight": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+            "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+            "dev": true
+        },
+        "inherits": {
+            "version": "2.0.3",
+            "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+            "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+            "dev": true
+        },
+        "inquirer": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-0.12.0.tgz",
+            "integrity": "sha1-HvK/1jUE3wvHV4X/+MLEHfEvB34=",
+            "dev": true
+        },
+        "interpret": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.0.3.tgz",
+            "integrity": "sha1-y8NcYu7uc/Gat7EKgBURQBr8D5A=",
+            "dev": true
+        },
+        "iron": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/iron/-/iron-4.0.5.tgz",
+            "integrity": "sha1-TwQszri5c480a1mqc0yDqJvDFCg=",
+            "dev": true
+        },
+        "is_js": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/is_js/-/is_js-0.9.0.tgz",
+            "integrity": "sha1-CrlFQFArp6+iTIVqqYVWFmnpxS0=",
+            "dev": true
+        },
+        "is-buffer": {
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.5.tgz",
+            "integrity": "sha1-Hzsm72E7IUuIy8ojzGwB2Hlh7sw=",
+            "dev": true
+        },
+        "is-fullwidth-code-point": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+            "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+            "dev": true
+        },
+        "is-my-json-valid": {
+            "version": "2.16.0",
+            "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.16.0.tgz",
+            "integrity": "sha1-8Hndm/2uZe4gOKrorLyGqxCeNpM=",
+            "dev": true
+        },
+        "is-path-cwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+            "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+            "dev": true
+        },
+        "is-path-in-cwd": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
+            "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
+            "dev": true
+        },
+        "is-path-inside": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.0.tgz",
+            "integrity": "sha1-/AbloWg/vaE95mev9xe7wQpI838=",
+            "dev": true
+        },
+        "is-property": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+            "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ=",
+            "dev": true
+        },
+        "is-resolvable": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/is-resolvable/-/is-resolvable-1.0.0.tgz",
+            "integrity": "sha1-jfV8YeouPFAUCNEA+wE8+NbgzGI=",
+            "dev": true
+        },
+        "isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+            "dev": true
+        },
+        "isemail": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.1.tgz",
+            "integrity": "sha1-A1PT2aYpUQgMJiwqoKQrjqjp4qY=",
+            "dev": true
+        },
+        "items": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/items/-/items-2.1.1.tgz",
+            "integrity": "sha1-i9FtnIOxlSneWuoyGsqtp4NkoZg=",
+            "dev": true
+        },
+        "joi": {
+            "version": "10.5.2",
+            "resolved": "https://registry.npmjs.org/joi/-/joi-10.5.2.tgz",
+            "integrity": "sha512-Do/NXTokq86nvFfggE4UbwNnyzvALn3Ay+gMwQSAkrQoWTYc4LvkabhypVZiqDZq0TbtVhUpOphe4dmKB6/Pxg==",
+            "dev": true
+        },
+        "js-tokens": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.1.tgz",
+            "integrity": "sha1-COnxMkhKLEWjCQfp3E1VZ7fxFNc=",
+            "dev": true
+        },
+        "js-yaml": {
+            "version": "3.8.4",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.8.4.tgz",
+            "integrity": "sha1-UgtFZPhlc7qWZir4Woyvp7S1pvY=",
+            "dev": true
+        },
+        "json-stable-stringify": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+            "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+            "dev": true
+        },
+        "json-stringify-safe": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
+        },
+        "jsonify": {
+            "version": "0.0.0",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+            "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
+            "dev": true
+        },
+        "jsonpointer": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
+            "integrity": "sha1-T9kss04OnbPInIYi7PUfm5eMbLk=",
+            "dev": true
+        },
+        "kind-of": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+            "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+            "dev": true
+        },
+        "lab": {
+            "version": "13.1.0",
+            "resolved": "https://registry.npmjs.org/lab/-/lab-13.1.0.tgz",
+            "integrity": "sha1-mD5lfQovDz1ibYBv+OArK89goPY=",
+            "dev": true
+        },
+        "lazy-cache": {
+            "version": "1.0.4",
+            "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+            "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
+            "dev": true,
+            "optional": true
+        },
+        "levn": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+            "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+            "dev": true
+        },
+        "lodash": {
+            "version": "4.17.4",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+            "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+            "dev": true
+        },
+        "lolex": {
+            "version": "1.6.0",
+            "resolved": "https://registry.npmjs.org/lolex/-/lolex-1.6.0.tgz",
+            "integrity": "sha1-OpoCg0UqR9dDnnJzG54H1zhuSfY=",
+            "dev": true
+        },
+        "longest": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+            "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
+            "dev": true
+        },
+        "lru-cache": {
+            "version": "2.2.4",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+            "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
+            "dev": true
+        },
+        "methods": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/methods/-/methods-1.0.1.tgz",
+            "integrity": "sha1-dbyRlD3/19oDfPPusO1zoAN80Us=",
+            "dev": true
+        },
+        "mime": {
+            "version": "1.2.11",
+            "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+            "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+            "dev": true
+        },
+        "mime-db": {
+            "version": "1.28.0",
+            "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.28.0.tgz",
+            "integrity": "sha1-/t00m+BtKGW3/FfYN8beTxfXrDw=",
+            "dev": true
+        },
+        "mimos": {
+            "version": "3.0.3",
+            "resolved": "https://registry.npmjs.org/mimos/-/mimos-3.0.3.tgz",
+            "integrity": "sha1-uRCQcq03jCty9qAQHEPd+ys2ZB8=",
+            "dev": true
+        },
+        "minimatch": {
+            "version": "3.0.4",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+            "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+            "dev": true
+        },
+        "minimist": {
+            "version": "0.0.8",
+            "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+            "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+            "dev": true
+        },
+        "mkdirp": {
+            "version": "0.5.1",
+            "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+            "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+            "dev": true
+        },
+        "ms": {
+            "version": "0.7.1",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
+            "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
+            "dev": true
+        },
+        "mute-stream": {
+            "version": "0.0.5",
+            "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.5.tgz",
+            "integrity": "sha1-j7+rsKmKJT0xhDMfno3rc3L6xsA=",
+            "dev": true
+        },
+        "native-promise-only": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
+            "integrity": "sha1-IKMYwwy0X3H+et+/eyHJnBRy7xE=",
+            "dev": true
+        },
+        "natural-compare": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+            "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+            "dev": true
+        },
+        "nigel": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/nigel/-/nigel-2.0.2.tgz",
+            "integrity": "sha1-k6GGb7DFLYc5CqdeKxYfS1x15bE=",
+            "dev": true
+        },
+        "no-arrowception": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/no-arrowception/-/no-arrowception-1.0.0.tgz",
+            "integrity": "sha1-W/PpXrnEG1c4SoBTM9qjtzTuMno=",
+            "dev": true
+        },
+        "number-is-nan": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+            "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+            "dev": true
+        },
+        "object-assign": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+            "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+            "dev": true
+        },
+        "once": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+            "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+            "dev": true
+        },
+        "onetime": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+            "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+            "dev": true
+        },
+        "optimist": {
+            "version": "0.6.1",
+            "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+            "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+            "dev": true,
+            "dependencies": {
+                "wordwrap": {
+                    "version": "0.0.3",
+                    "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                    "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc=",
+                    "dev": true
+                }
+            }
+        },
+        "optionator": {
+            "version": "0.8.2",
+            "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+            "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+            "dev": true
+        },
+        "os-homedir": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+            "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+            "dev": true
+        },
+        "path-is-absolute": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+            "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+            "dev": true
+        },
+        "path-is-inside": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+            "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+            "dev": true
+        },
+        "path-parse": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+            "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
+            "dev": true
+        },
+        "path-to-regexp": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
+            "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
+            "dev": true
+        },
+        "pathval": {
+            "version": "1.1.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.0.tgz",
+            "integrity": "sha1-uULm1L3mUwBe9rcTYd74cn0GReA=",
+            "dev": true
+        },
+        "pez": {
+            "version": "2.1.5",
+            "resolved": "https://registry.npmjs.org/pez/-/pez-2.1.5.tgz",
+            "integrity": "sha1-XsLMYlAMw+tCNtSkFM9aF7XrUAc=",
+            "dev": true
+        },
+        "pify": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+            "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+            "dev": true
+        },
+        "pinkie": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+            "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA=",
+            "dev": true
+        },
+        "pinkie-promise": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+            "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+            "dev": true
+        },
+        "pluralize": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/pluralize/-/pluralize-1.2.1.tgz",
+            "integrity": "sha1-0aIUg/0iu0HlihL6NCGCMUCJfEU=",
+            "dev": true
+        },
+        "podium": {
+            "version": "1.2.5",
+            "resolved": "https://registry.npmjs.org/podium/-/podium-1.2.5.tgz",
+            "integrity": "sha1-h8VmwvA2W88KHsdgLE0BlIzdKtU=",
+            "dev": true
+        },
+        "pre-commit": {
+            "version": "0.0.9",
+            "resolved": "https://registry.npmjs.org/pre-commit/-/pre-commit-0.0.9.tgz",
+            "integrity": "sha1-uOjikwwONViur6G4lwYgPXcrl8s=",
+            "dev": true
+        },
+        "prelude-ls": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+            "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+            "dev": true
+        },
+        "process-nextick-args": {
+            "version": "1.0.7",
+            "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+            "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
+            "dev": true
+        },
+        "progress": {
+            "version": "1.1.8",
+            "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+            "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74=",
+            "dev": true
+        },
+        "qs": {
+            "version": "0.6.6",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-0.6.6.tgz",
+            "integrity": "sha1-bgFQmP9RlouKPIGQAdXyyJvEsQc=",
+            "dev": true
+        },
+        "readable-stream": {
+            "version": "1.0.27-1",
+            "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.27-1.tgz",
+            "integrity": "sha1-a2eYPCA1fO/QfwFlABoW1xDZEHg=",
+            "dev": true
+        },
+        "readline2": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz",
+            "integrity": "sha1-QQWWCP/BVHV7cV2ZidGZ/783LjU=",
+            "dev": true
+        },
+        "rechoir": {
+            "version": "0.6.2",
+            "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+            "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+            "dev": true
+        },
+        "reduce-component": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/reduce-component/-/reduce-component-1.0.1.tgz",
+            "integrity": "sha1-4Mk1QsV0UhvqE98PlIjtgqt3xdo=",
+            "dev": true
+        },
+        "repeat-string": {
+            "version": "1.6.1",
+            "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+            "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
+            "dev": true
+        },
+        "request-ip": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/request-ip/-/request-ip-2.0.1.tgz",
+            "integrity": "sha1-EPv5cbpz4d1rrywyUnW209TBCnE=",
+            "dev": true
+        },
+        "require-uncached": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
+            "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
+            "dev": true
+        },
+        "resolve": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.3.3.tgz",
+            "integrity": "sha1-ZVkHw0aahoDcLeOidaj91paR8OU=",
+            "dev": true
+        },
+        "resolve-from": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-1.0.1.tgz",
+            "integrity": "sha1-Jsv+k10a7uq7Kbw/5a6wHpPUQiY=",
+            "dev": true
+        },
+        "restore-cursor": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+            "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+            "dev": true
+        },
+        "right-align": {
+            "version": "0.1.3",
+            "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+            "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+            "dev": true,
+            "optional": true
+        },
+        "rimraf": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.1.tgz",
+            "integrity": "sha1-wjOOxkPfeht/5cVPqG9XQopV8z0=",
+            "dev": true
+        },
+        "rollbar": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/rollbar/-/rollbar-2.0.4.tgz",
+            "integrity": "sha1-EbiuWoh1r1jW846j9DwCLdTVoyg=",
+            "dev": true,
+            "dependencies": {
+                "extend": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+                    "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ=",
+                    "dev": true
+                },
+                "uuid": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+                    "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE=",
+                    "dev": true
+                }
+            }
+        },
+        "run-async": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/run-async/-/run-async-0.1.0.tgz",
+            "integrity": "sha1-yK1KXhEGYeQCp9IbUw4AnyX444k=",
+            "dev": true
+        },
+        "rx-lite": {
+            "version": "3.1.2",
+            "resolved": "https://registry.npmjs.org/rx-lite/-/rx-lite-3.1.2.tgz",
+            "integrity": "sha1-Gc5QLKVyZl87ZHsQk5+X/RYV8QI=",
+            "dev": true
+        },
+        "safe-buffer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+            "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c=",
+            "dev": true
+        },
+        "samsam": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.2.1.tgz",
+            "integrity": "sha1-7dOQk6MYQ3DLhZJDsr3yVefY6mc=",
+            "dev": true
+        },
+        "seedrandom": {
+            "version": "2.4.3",
+            "resolved": "https://registry.npmjs.org/seedrandom/-/seedrandom-2.4.3.tgz",
+            "integrity": "sha1-JDhQTa0zkXMUv/GKxNeU8W1qrsw=",
+            "dev": true
+        },
+        "shelljs": {
+            "version": "0.7.8",
+            "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.7.8.tgz",
+            "integrity": "sha1-3svPh0sNHl+3LhSxZKloMEjprLM=",
+            "dev": true
+        },
+        "shot": {
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/shot/-/shot-3.4.2.tgz",
+            "integrity": "sha1-Hlw/bysmZJrcQvfrNQIUpaApHWc=",
+            "dev": true
+        },
+        "sinon": {
+            "version": "2.3.4",
+            "resolved": "https://registry.npmjs.org/sinon/-/sinon-2.3.4.tgz",
+            "integrity": "sha1-RmrY0brobW21GqIYuS6Ze8Pl24g=",
+            "dev": true
+        },
+        "slice-ansi": {
+            "version": "0.0.4",
+            "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+            "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+            "dev": true
+        },
+        "source-map": {
+            "version": "0.5.6",
+            "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.6.tgz",
+            "integrity": "sha1-dc449SvwczxafwwRjYEzSiu19BI=",
+            "dev": true
+        },
+        "source-map-support": {
+            "version": "0.4.15",
+            "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.15.tgz",
+            "integrity": "sha1-AyAt9lwG0r2MfsI2KhkwVv7407E=",
+            "dev": true
+        },
+        "sprintf-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+            "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+            "dev": true
+        },
+        "stackframe": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/stackframe/-/stackframe-0.3.1.tgz",
+            "integrity": "sha1-M6qE8Rd6VUjIk1Uzy/6zQgl19aQ=",
+            "dev": true
+        },
+        "statehood": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/statehood/-/statehood-5.0.2.tgz",
+            "integrity": "sha1-xrO6oW7YsSHT8Jo/+oXiIZWn8qk=",
+            "dev": true
+        },
+        "string_decoder": {
+            "version": "0.10.31",
+            "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+            "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+            "dev": true
+        },
+        "string-width": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+            "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+            "dev": true
+        },
+        "strip-ansi": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+            "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+            "dev": true
+        },
+        "strip-bom": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+            "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+            "dev": true
+        },
+        "strip-json-comments": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+            "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+            "dev": true
+        },
+        "subtext": {
+            "version": "4.4.1",
+            "resolved": "https://registry.npmjs.org/subtext/-/subtext-4.4.1.tgz",
+            "integrity": "sha1-L87JRd5CkoPD0YsVH/D6HxuHrsk=",
+            "dev": true
+        },
+        "superagent": {
+            "version": "0.18.2",
+            "resolved": "https://registry.npmjs.org/superagent/-/superagent-0.18.2.tgz",
+            "integrity": "sha1-mvxidqlHX0vc1TWsagaF68S1YOs=",
+            "dev": true,
+            "dependencies": {
+                "debug": {
+                    "version": "1.0.4",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-1.0.4.tgz",
+                    "integrity": "sha1-W5wla9VLbsAigxdvqKDt5tFUy/g=",
+                    "dev": true
+                },
+                "ms": {
+                    "version": "0.6.2",
+                    "resolved": "https://registry.npmjs.org/ms/-/ms-0.6.2.tgz",
+                    "integrity": "sha1-2JwhJMb9wTU9Zai3e/GqxLGTcIw=",
+                    "dev": true
+                }
+            }
+        },
+        "table": {
+            "version": "3.8.3",
+            "resolved": "https://registry.npmjs.org/table/-/table-3.8.3.tgz",
+            "integrity": "sha1-K7xULw/amGGnVdOUf+/Ys/UThV8=",
+            "dev": true,
+            "dependencies": {
+                "is-fullwidth-code-point": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+                    "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+                    "dev": true
+                },
+                "string-width": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
+                    "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
+                    "dev": true
+                }
+            }
+        },
+        "text-encoding": {
+            "version": "0.6.4",
+            "resolved": "https://registry.npmjs.org/text-encoding/-/text-encoding-0.6.4.tgz",
+            "integrity": "sha1-45mpgiV6J22uQou5KEXLcb3CbRk=",
+            "dev": true
+        },
+        "text-table": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+            "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+            "dev": true
+        },
+        "through": {
+            "version": "2.3.8",
+            "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+            "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+            "dev": true
+        },
+        "topo": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.2.tgz",
+            "integrity": "sha1-zVYVdSU5BXwNwEkaYhw7xvvh0YI=",
+            "dev": true
+        },
+        "traverse-chain": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
+            "integrity": "sha1-YdvC1Ttp/2CRoSoWj9fUMxB+QPE=",
+            "dev": true,
+            "optional": true
+        },
+        "tryit": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tryit/-/tryit-1.0.3.tgz",
+            "integrity": "sha1-OTvnMKlEb9Hq1tpZoBQwjzbCics=",
+            "dev": true
+        },
+        "type-check": {
+            "version": "0.3.2",
+            "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+            "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+            "dev": true
+        },
+        "type-detect": {
+            "version": "4.0.3",
+            "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.3.tgz",
+            "integrity": "sha1-Dj8mcLRAmbC0bChNE2p+9Jx0wuo=",
+            "dev": true
+        },
+        "typedarray": {
+            "version": "0.0.6",
+            "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+            "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=",
+            "dev": true
+        },
+        "uglify-js": {
+            "version": "2.8.28",
+            "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.28.tgz",
+            "integrity": "sha512-WqKNbmNJKzIdIEQu/U2ytgGBbhCy2PVks94GoetczOAJ/zCgVu2CuO7gguI5KPFGPtUtI1dmPQl6h0D4cPzypA==",
+            "dev": true,
+            "optional": true
+        },
+        "uglify-to-browserify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+            "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
+            "dev": true,
+            "optional": true
+        },
+        "user-home": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/user-home/-/user-home-2.0.0.tgz",
+            "integrity": "sha1-nHC/2Babwdy/SGBODwS4tJzenp8=",
+            "dev": true
+        },
+        "util-deprecate": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+            "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+            "dev": true
+        },
+        "vise": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/vise/-/vise-2.0.2.tgz",
+            "integrity": "sha1-awjo+0y3bjpQzW3Q7DczjoEaDTk=",
+            "dev": true
+        },
+        "window-size": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+            "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
+            "dev": true,
+            "optional": true
+        },
+        "wordwrap": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+            "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+            "dev": true
+        },
+        "wrappy": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+            "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+            "dev": true
+        },
+        "wreck": {
+            "version": "12.2.2",
+            "resolved": "https://registry.npmjs.org/wreck/-/wreck-12.2.2.tgz",
+            "integrity": "sha1-4hgj00w21nIATu+jR66MT2BQ49s=",
+            "dev": true
+        },
+        "write": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
+            "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
+            "dev": true
+        },
+        "xtend": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+            "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+            "dev": true
+        },
+        "yargs": {
+            "version": "3.10.0",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+            "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+            "dev": true,
+            "optional": true
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "author": "Evangelos Pappas <epappas@evalonlabs.com>",
     "engine": "node >= 0.10.x",
     "scripts": {
-        "test": "mocha test"
+        "test": "lab test"
     },
     "repository": {
         "type": "git",
@@ -24,18 +24,18 @@
         "hapi",
         "plugin"
     ],
-    "dependencies": {
-        "rollbar": "^0.5.11"
-    },
+    "dependencies": {},
     "peerDependencies": {
-        "rollbar": "0.x.x",
-	"hapi": "16.x.x"
+        "rollbar": "2.x.x",
+        "hapi": "16.x.x"
     },
     "devDependencies": {
-        "mocha": "^1.18.2",
-        "should": "^3.3.1",
-        "superagent": "^0.18.0",
+        "chai": "^4.0.2",
+        "hapi": "^16.4.2",
+        "lab": "^13.1.0",
         "pre-commit": "0.0.9",
-        "rollbar": "^0.5.11"
+        "rollbar": "^2.0.4",
+        "sinon": "^2.3.4",
+        "superagent": "^0.18.0"
     }
 }


### PR DESCRIPTION
connects soxhub/qa#2976

Upgraded rollbar to '2.0.4'.

Updated rollbar inititalization code.
Updated use of deprecated rollbar methods to new interface.
Deleted call to `rollbar.shutdown`; the `shutdown` method
doesn't exit in the new version of rollbar.

Deleted exported server methods that were calling the deprecated rollbar
api.  The rollbar instance is exposed to the server and it can be
used to interact with the rollbar api as needed.

Also updated mocha to the latest version to eliminate the deprecation
warning appearing when tests were run.