### PR TITLE
Update package.json for soxhub

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-    "name": "rollbar-hapi",
+    "name": "@soxhub/rollbar-hapi",
     "version": "0.0.10",
     "description": "A Hapi plugin for rollbar painless integration",
-    "author": "Evangelos Pappas <epappas@evalonlabs.com>",
+    "author": "SOXHUB <engineering@soxhub.com>",
     "engine": "node >= 0.10.x",
     "scripts": {
         "test": "lab test"
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/epappas/rollbar-hapi.git"
+        "url": "https://github.com/soxhub/rollbar-hapi.git"
     },
     "pre-commit": [
         "test"


### PR DESCRIPTION
Publishing to https://www.npmjs.com/package/@soxhub/rollbar-hapi so we don't need to use Git urls in package.json.